### PR TITLE
Replace deprecated filter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ A **self-hosted** disposable mailbox  service (aka trash mail)  :cloud: :envelop
 * New Mail notification. Download and delete your emails.
 * Display emails as text or html with sanitization  filter. 
 * Display emails based on one [catch-all imap mailbox](https://de.wikipedia.org/wiki/Catch-All).
-* Only requires PHP  >=7.2 and [imap extension](http://php.net/manual/book.imap.php)
+* Only requires PHP  >=8.3 and [imap extension](http://php.net/manual/book.imap.php)
+* Optional Dark Mode interface
 
 ## Usage
 
 ### Requirements
 
-* webserver with php >=7.2
+* webserver with php >=8.3
 * php [imap extension](http://php.net/manual/book.imap.php)
 * IMAP account and a domain with [catch-all configuration](https://www.hoststar.ch/de/support/mail/konfigurieren/catch-all). (all emails go to one mailbox). 
 

--- a/src/User.php
+++ b/src/User.php
@@ -8,11 +8,16 @@ class User {
     public string $domain;
 
     public static function get_random_address(array $domains): string {
-        $wordLength = rand(3, 8);
+        try {
+            $wordLength = random_int(3, 8);
+            $nr = random_int(51, 91);
+        } catch (\Exception $e) {
+            $wordLength = mt_rand(3, 8);
+            $nr = mt_rand(51, 91);
+        }
         $container = new PronounceableWord_DependencyInjectionContainer();
         $generator = $container->getGenerator();
         $word = $generator->generateWordOfGivenLength($wordLength);
-        $nr = rand(51, 91);
         $name = $word . $nr;
 
         $domain = $domains[array_rand($domains)];

--- a/src/assets/custom.css
+++ b/src/assets/custom.css
@@ -49,6 +49,13 @@ header {
     /*background-color: #f9f9f9;*/
     padding-bottom: 1rem;
     padding-top: 1rem;
+    position: relative;
+}
+
+.header-section .theme-switch {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
 }
 
 main {
@@ -91,7 +98,7 @@ footer {
     display: block;
 }
 
-#new-content-avalable {
+#new-content-available {
     display: none;
     text-align: center;
 }
@@ -111,4 +118,77 @@ footer {
 }
 #address-box-edit {
     margin: 1rem;
+}
+body.dark-mode {
+    background-color: #121212;
+    color: #e0e0e0;
+}
+
+body.dark-mode .container,
+body.dark-mode .header-section,
+body.dark-mode .email-content,
+body.dark-mode .details,
+body.dark-mode .privacy {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+}
+
+body.dark-mode .email-content:hover {
+    background-color: #2a2a2a;
+}
+
+body.dark-mode a {
+    color: #4ea8ff;
+}
+
+body.dark-mode .alert-fixed {
+    background-color: #333;
+    color: #fff;
+}
+
+.theme-switch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 24px;
+}
+
+.theme-switch input {
+    display: none;
+}
+
+.theme-switch .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: background-color 0.3s;
+    border-radius: 34px;
+}
+
+.theme-switch .slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: transform 0.3s;
+    border-radius: 50%;
+}
+
+input#theme-toggle:checked + .slider {
+    background-color: #007bff;
+}
+
+input#theme-toggle:checked + .slider:before {
+    transform: translateX(26px);
+}
+
+body.dark-mode .theme-switch .slider {
+    background-color: #555;
 }

--- a/src/config_helper.php
+++ b/src/config_helper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * searches for a config-file in the current and parent directories until found.
  * @return path to found config file, or FALSE otherwise.

--- a/src/controller.php
+++ b/src/controller.php
@@ -19,7 +19,7 @@ class DisplayEmailsController {
     }
 
     public static function invoke(ImapClient $imapClient, array $config): void {
-        $address = filter_var($_SERVER['QUERY_STRING'] ?? '', FILTER_SANITIZE_STRING);
+        $address = trim(filter_var($_SERVER['QUERY_STRING'] ?? '', FILTER_UNSAFE_RAW));
         $user = User::parseDomain($address, $config['blocked_usernames']);
 
         if ($user->isInvalid($config['domains'])) {
@@ -44,8 +44,8 @@ class RedirectToAddressController {
     }
 
     public static function invoke(ImapClient $imapClient, array $config): void {
-        $username = filter_var($_POST['username'], FILTER_SANITIZE_STRING);
-        $domain = filter_var($_POST['domain'], FILTER_SANITIZE_STRING);
+        $username = trim(filter_var($_POST['username'], FILTER_UNSAFE_RAW));
+        $domain = trim(filter_var($_POST['domain'], FILTER_UNSAFE_RAW));
         $user = User::parseUsernameAndDomain($username, $domain, $config['blocked_usernames']);
 
         self::render($user->username . '@' . $user->domain);
@@ -75,8 +75,8 @@ class HasNewMessagesControllerJson {
     }
 
     public static function invoke(ImapClient $imapClient, array $config): void {
-        $email_ids = explode('|', filter_var($_GET['email_ids'], FILTER_SANITIZE_STRING));
-        $address = filter_var($_GET['address'], FILTER_SANITIZE_STRING);
+        $email_ids = explode('|', trim(filter_var($_GET['email_ids'], FILTER_UNSAFE_RAW)));
+        $address = trim(filter_var($_GET['address'], FILTER_UNSAFE_RAW));
 
         $user = User::parseDomain($address, $config['blocked_usernames']);
         if ($user->isInvalid($config['domains'])) {
@@ -104,7 +104,7 @@ class DownloadEmailController {
 
     public static function invoke(ImapClient $imapClient, array $config): void {
         $email_id = filter_var($_GET['email_id'], FILTER_SANITIZE_NUMBER_INT);
-        $address = filter_var($_GET['address'], FILTER_SANITIZE_STRING);
+        $address = trim(filter_var($_GET['address'], FILTER_UNSAFE_RAW));
 
         $user = User::parseDomain($address, $config['blocked_usernames']);
         if ($user->isInvalid($config['domains'])) {
@@ -136,7 +136,7 @@ class DeleteEmailController {
 
     public static function invoke(ImapClient $imapClient, array $config): void {
         $email_id = filter_var($_GET['email_id'], FILTER_SANITIZE_NUMBER_INT);
-        $address = filter_var($_GET['address'], FILTER_SANITIZE_STRING);
+        $address = trim(filter_var($_GET['address'], FILTER_UNSAFE_RAW));
 
         $user = User::parseDomain($address, $config['blocked_usernames']);
         if ($user->isInvalid($config['domains'])) {

--- a/src/frontend.template.php
+++ b/src/frontend.template.php
@@ -184,6 +184,10 @@ function printMessageBody($email, $purifier) {
     <header class="header-section">
         <h1>Deine Einweg-Mailbox</h1>
         <p>Erstelle schnell und einfach eine temporäre E-Mail-Adresse!</p>
+        <label class="theme-switch mb-2">
+            <input type="checkbox" id="theme-toggle">
+            <span class="slider"></span>
+        </label>
     </header>
 
     <!-- Adresse anzeigen und Kopieren -->
@@ -293,6 +297,31 @@ function printMessageBody($email, $purifier) {
 <script src="assets/clipboard.js/clipboard.min.js"></script>
 <script>
     clipboard = new ClipboardJS('[data-clipboard-target]');
+</script>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var body = document.body;
+        var toggle = document.getElementById('theme-toggle');
+
+        function applyTheme(theme) {
+            if (theme === 'dark') {
+                body.classList.add('dark-mode');
+                toggle.checked = true;
+            } else {
+                body.classList.remove('dark-mode');
+                toggle.checked = false;
+            }
+        }
+
+        var saved = localStorage.getItem('theme');
+        applyTheme(saved === 'dark' ? 'dark' : 'light');
+
+        toggle.addEventListener('change', function () {
+            var isDark = toggle.checked;
+            applyTheme(isDark ? 'dark' : 'light');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        });
+    });
 </script>
 
 </body>

--- a/src/index.php
+++ b/src/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // check for common errors
-if (version_compare(phpversion(), '7.2', '<')) {
-    die("ERROR! The php version isn't high enough, you need at least 7.2 to run this application! But you have: " . phpversion());
+if (version_compare(phpversion(), '8.3', '<')) {
+    die("ERROR! The php version isn't high enough, you need at least 8.3 to run this application! But you have: " . phpversion());
 }
 extension_loaded("imap") || die('ERROR: IMAP extension not loaded. Please see the installation instructions in the README.md');
 


### PR DESCRIPTION
## Summary
- replace deprecated FILTER_SANITIZE_STRING with FILTER_UNSAFE_RAW + trim in controller
- update PHP 8.3 requirement in README and runtime check
- fix CSS ID for new message notification
- add strict_types declaration to config helper
- use random_int for address generation
- add optional dark mode theme with toggle
- improve dark mode toggle and add fallback for random addresses

## Testing
- `php -l src/config_helper.php` *(fails: `php` not installed)*
- `php -l src/User.php` *(fails: `php` not installed)*
- `php -l src/frontend.template.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869999ef768832e95ce5e95263f7b5e